### PR TITLE
Fix uninitialized display values

### DIFF
--- a/src/visualization/display_communication.cpp
+++ b/src/visualization/display_communication.cpp
@@ -20,7 +20,8 @@ const unsigned long updateInterval = 120000; // 2 Minuten
  * @param rstPin Reset pin for the display.
  */
 DisplayCommunication::DisplayCommunication(int8_t csPin, int8_t dcPin, int8_t mosiPin, int8_t sclkPin, int8_t rstPin)
-    : tft(Adafruit_ST7789(csPin, dcPin, mosiPin, sclkPin, rstPin)) {}
+    : tft(Adafruit_ST7789(csPin, dcPin, mosiPin, sclkPin, rstPin)),
+      lastTemperature(0), lastHumidity(0), lastPressure(0) {}
 
 /**
  * @brief Initializes the display.


### PR DESCRIPTION
## Summary
- initialize previous temperature, humidity and pressure values

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6840a77b492c8328b97f7f872c774e5d