### PR TITLE
docs: clarify roles and operations

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,47 @@
+# Operations
+
+## Device Roles
+
+`SkySentinel` currently supports two concrete firmware roles:
+
+- `saola`: outdoor station, reads BME280 values, publishes MQTT telemetry, exposes OTA handling
+- `kaluga`: indoor display node, subscribes to the shared MQTT topics and renders the latest values locally
+
+Both roles share the same topic constants and credentials layout, but only the outdoor node publishes sensor values.
+
+## Canonical Build Targets
+
+```bash
+platformio run -e saola
+platformio run -e kaluga
+```
+
+Upload over USB or your configured OTA target:
+
+```bash
+platformio run -e saola -t upload
+platformio run -e kaluga -t upload
+```
+
+## OTA Control
+
+The outdoor node subscribes to:
+
+- `weather/outdoor/ota`
+
+Publishing payload `1` to that topic requests an OTA maintenance window and keeps the device awake for update handling.
+
+## Practical Operator Checks
+
+After flashing or OTA upload, verify:
+
+1. the node joins Wi-Fi with the configured `WIFI_HOSTNAME`
+2. MQTT telemetry reaches `weather/outdoor/*`
+3. Home Assistant discovery entities appear for the outdoor station
+4. the indoor display updates after new outdoor messages arrive
+
+## Local Configuration Rules
+
+- keep `src/credentials.h` local and untracked
+- keep environment-specific OTA IPs or hostnames aligned with your own network
+- do not hardcode secrets into tracked files

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ doc/                 generated Doxygen output
 
 - [SETUP.md](SETUP.md)
 - [STATUS.md](STATUS.md)
+- [OPERATIONS.md](OPERATIONS.md)
+- [TOPIC_CONTRACT.md](TOPIC_CONTRACT.md)
 - [ROADMAP.md](ROADMAP.md)
 - generated API docs in [doc](doc/)
 
@@ -115,6 +117,8 @@ doc/                 generierte Doxygen-Dokumentation
 
 - [SETUP.md](SETUP.md)
 - [STATUS.md](STATUS.md)
+- [OPERATIONS.md](OPERATIONS.md)
+- [TOPIC_CONTRACT.md](TOPIC_CONTRACT.md)
 - [ROADMAP.md](ROADMAP.md)
 - generierte API-Doku unter [doc](doc/)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,11 +32,11 @@ This roadmap outlines the planned features and improvements for the Modular Weat
    e. Implement an alerting function for specific weather conditions
 
 6. **OTA (Over-the-Air) functionality:**
-   - Implement OTA updates for the weather station firmware
+   - Harden OTA updates for the weather station firmware and maintenance flows
 
 7. **Integration with home automation systems:**
    a. Integrate with ioBroker
-   b. Integrate with Home Assistant
+   b. Extend the existing Home Assistant MQTT discovery integration
 
 ### Deutsch
 
@@ -70,11 +70,11 @@ Diese Roadmap skizziert die geplanten Funktionen und Verbesserungen für das mod
    e. Implementierung einer Alarmierungsfunktion für bestimmte Wetter
 
 6. **OTA (Over-the-Air)-Funktionalität:**
-   - Implementierung von OTA-Updates für die Firmware der Wetterstation
+   - Härtung von OTA-Updates und Wartungsabläufen für die Wetterstations-Firmware
 
 7. **Integration in Hausautomatisierungssysteme:**
    a. Integration in ioBroker
-   b. Integration in Home Assistant
+   b. Ausbau der vorhandenen Home-Assistant-MQTT-Discovery-Integration
 
 ### Status
 | Status | Priority | Task | Description (English) | Beschreibung (Deutsch) | Complexity |
@@ -88,6 +88,6 @@ Diese Roadmap skizziert die geplanten Funktionen und Verbesserungen für das mod
 | [-] | 7 | Web App on ESP32 | Minimalistic web app for live data and configuration (not started) | Minimalistische Webanwendung für Live-Daten und Konfiguration (nicht begonnen) | Medium |
 | [ ] | 8 | API Development | Development of an API (not started) | Entwicklung einer API (nicht begonnen) | Medium |
 | [ ] | 9 | Server-based Web App (Raspberry Pi example) | Server-based web app with Docker integration (not started) | Serverbasierte Webanwendung mit Docker-Integration (nicht begonnen) | High |
-| [ ] | 10 | OTA Updates | Over-the-Air updates (not started) | OTA-Updates (nicht begonnen) | Medium |
+| [~] | 10 | OTA Updates | OTA support exists; the next step is hardening update and maintenance behavior | OTA-Unterstützung existiert; als Nächstes folgt die Härtung von Update- und Wartungsverhalten | Medium |
 | [ ] | 11 | Additional Sensors Integration | Integration of additional sensors (not started) | Integration zusätzlicher Sensoren (nicht begonnen) | High |
-| [ ] | 12 | Integration into Home Automation Systems | Integration into ioBroker and Home Assistant (not started) | Integration in ioBroker und Home Assistant (nicht begonnen) | Medium |
+| [~] | 12 | Integration into Home Automation Systems | Home Assistant MQTT discovery exists; ioBroker and broader automation integration remain open | Home-Assistant-MQTT-Discovery existiert; ioBroker und breitere Automatisierungsintegration sind noch offen | Medium |

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,12 +14,16 @@ This project uses [PlatformIO](https://platformio.org/) for building and uploadi
 1. Clone this repository.
 2. Copy `src/credentials_template.h` to `src/credentials.h` and edit the file with your Wi-Fi and MQTT credentials.
 3. Set an optional `WIFI_HOSTNAME` if you want a stable DHCP/OTA name.
-4. Review `platformio.ini` for the correct board environment, display pins, and upload settings.
-5. Build the firmware with `platformio run` or using the build button in PlatformIO.
-6. Connect your board via USB and upload the firmware with `platformio run -t upload`.
-7. If OTA is configured for your environment, you can also use the configured OTA upload target from `platformio.ini`.
-8. After flashing, the device will connect to Wi-Fi and publish sensor data via MQTT.
-9. If Home Assistant MQTT discovery is enabled on your broker, the outdoor station will also publish entity discovery payloads.
+4. Choose the correct board role in `platformio.ini`:
+   - `saola` for the outdoor sensor node
+   - `kaluga` for the indoor display node
+5. Review the board-specific display pins and upload settings in `platformio.ini`.
+6. Build the firmware with `platformio run -e saola` or `platformio run -e kaluga`.
+7. Connect your board via USB and upload with `platformio run -e <env> -t upload`.
+8. If OTA is configured for your environment, you can also use the configured OTA upload target from `platformio.ini`.
+9. After flashing, the outdoor node will publish sensor data via MQTT and the indoor node will subscribe to the shared topics.
+10. If Home Assistant MQTT discovery is enabled on your broker, the outdoor station will also publish retained discovery payloads.
+11. For OTA maintenance, publish `1` to `weather/outdoor/ota` and keep the device reachable on the network.
 
 ## Documentation
 
@@ -29,3 +33,4 @@ Pre-built API documentation is located in the `doc` directory. Run `doxygen doxy
 
 - `src/credentials.h` is local machine configuration and should stay untracked.
 - Keep environment-specific IP addresses and OTA targets aligned with your own network before flashing.
+- Review [OPERATIONS.md](OPERATIONS.md) and [TOPIC_CONTRACT.md](TOPIC_CONTRACT.md) before changing role behavior or MQTT paths.

--- a/STATUS.md
+++ b/STATUS.md
@@ -19,16 +19,18 @@ The current codebase already covers the core weather-station loop:
 - shared topic definitions for weather data
 - Home Assistant discovery publishing
 - ring-buffer based weather data storage
+- OTA handling in the outdoor node runtime
+- indoor display rendering from shared MQTT topics
 
 ## What Still Needs Work
 
-- clearer operator-facing setup notes for OTA deployments
-- more explicit distinction between indoor and outdoor device roles
 - more unit tests around MQTT callback and reconnect behavior
 - cleaner separation between generated docs and authored docs
+- board-role and operations docs must stay aligned with `platformio.ini`
 
 ## Current Risk Areas
 
 - OTA and Wi-Fi reconnect paths are operationally sensitive
 - board-specific pin definitions remain configuration-heavy
 - local network deployment details can drift from checked-in docs
+- MQTT payload handling is still simple and should remain tightly scoped

--- a/TOPIC_CONTRACT.md
+++ b/TOPIC_CONTRACT.md
@@ -1,0 +1,41 @@
+# Topic Contract
+
+## Shared Base Topics
+
+- `weather/indoor`
+- `weather/outdoor`
+
+## Outdoor Telemetry
+
+- `weather/outdoor/temperature`
+- `weather/outdoor/humidity`
+- `weather/outdoor/pressure`
+
+The outdoor node publishes these values after each successful sensor read and MQTT reconnect.
+
+## Indoor Display Inputs
+
+- `weather/outdoor/temperature`
+- `weather/outdoor/humidity`
+- `weather/outdoor/pressure`
+
+The indoor display node consumes the same outdoor telemetry and renders the latest values locally.
+
+## OTA Control
+
+- `weather/outdoor/ota`
+
+Payload `1` signals that the outdoor node should stay awake for OTA handling.
+
+## Home Assistant Discovery
+
+The outdoor station publishes retained discovery payloads under:
+
+- `homeassistant/sensor/weather_outdoor_station/temperature/config`
+- `homeassistant/sensor/weather_outdoor_station/humidity/config`
+- `homeassistant/sensor/weather_outdoor_station/pressure/config`
+
+## Device Identifiers
+
+- `weather_indoor_station`
+- `weather_outdoor_station`

--- a/src/data_processing/README.md
+++ b/src/data_processing/README.md
@@ -1,2 +1,8 @@
 # Data Processing
-Hier werden Skripte zur Datenverarbeitung und -speicherung gespeichert
+
+This directory contains the lightweight data-processing helpers used by the firmware.
+
+- `ring_buffer.*`: shared rolling storage for sampled values
+- `data_processing.*`: higher-level helpers built on top of the ring buffer
+
+These components are intentionally small so they can be reused on resource-constrained boards.

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -1,2 +1,9 @@
-# SeExamplesnsors
-Hier werden Beispielanwendungen und -konfigurationen gespeichert
+# Examples
+
+This directory is reserved for future sample sketches and role-specific configuration examples.
+
+At the moment, the canonical operational examples live in:
+
+- [SETUP.md](../../SETUP.md)
+- [OPERATIONS.md](../../OPERATIONS.md)
+- [TOPIC_CONTRACT.md](../../TOPIC_CONTRACT.md)

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -1,2 +1,8 @@
-# Communication
-Hier werden die Kommunikationsmodule (z.B. WiFi, LoRa, etc) gespeichert
+# Network
+
+This directory contains the Wi-Fi and MQTT communication layers for `SkySentinel`.
+
+- `wifi_communication.*`: Wi-Fi setup, connection handling, and hostname usage
+- `mqtt_communication.*`: MQTT reconnect logic, telemetry publishing, subscriptions, and Home Assistant discovery
+
+The current firmware uses MQTT as the canonical transport between the outdoor node and the indoor display node.

--- a/src/sensors/README.md
+++ b/src/sensors/README.md
@@ -1,2 +1,9 @@
 # Sensors
-Hier werden die Sensor Module gespeichert
+
+This directory contains sensor integrations for the firmware.
+
+The current primary implementation is:
+
+- `bme280_communication.*`: temperature, humidity, and pressure reads for the outdoor station
+
+Future sensor work should extend this layer instead of hardcoding reads directly into `main.cpp`.

--- a/src/visualization/README.md
+++ b/src/visualization/README.md
@@ -1,2 +1,5 @@
 # Visualization
-Hier werden Skripte und Module zur Datenvisalisierung und zur Erstellung einer Webanwendung oder mobilen App gespeichert
+
+This directory contains display-facing code for the indoor station.
+
+The current implementation focuses on lightweight local rendering of the latest MQTT-fed weather values on supported ESP32-S2 boards.


### PR DESCRIPTION
## Summary
- document the two concrete device roles and the MQTT topic contract
- update setup, status, and roadmap to reflect the current firmware state
- replace placeholder module README files with operator- and maintainer-facing guidance

## Verification
- python -m platformio run
- git diff --check